### PR TITLE
feat: ship ESLint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ dist
 *.cjs
 *.mjs
 *.d.ts
+eslint-config

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.mjs
 *.cjs
 *.d.ts
+eslint-config

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Object.assign(window, Vue)
 
 In [the latest `<script setup>`](https://github.com/vuejs/rfcs/pull/227), compile time macros like `defineProps` and `defineEmits` are now available globally without the need to import them from `vue`. So, as your components are likely to rely on composition APIs like `ref` and `computed`, why don't we just have them available globally as well?
 
-## Eslint
+## ESLint
 
 If you use ESLint it'll complain about you using undefined variables. This package provides a ESLint config you can extend from that will fix those issues.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,37 @@ Object.assign(window, Vue)
 
 In [the latest `<script setup>`](https://github.com/vuejs/rfcs/pull/227), compile time macros like `defineProps` and `defineEmits` are now available globally without the need to import them from `vue`. So, as your components are likely to rely on composition APIs like `ref` and `computed`, why don't we just have them available globally as well?
 
+## Eslint
+
+If you use ESLint it'll complain about you using undefined variables. This package provides a ESLint config you can extend from that will fix those issues.
+
+Just extend the config in your `.eslintrc.js`:
+
+```javascript
+module.exports = {
+  extends: [
+    'vue-global-api-main/eslint-config'
+  ]
+};
+```
+
+This provides the same collections and single API options to allow you to have more fine-grain control.
+
+```javascript
+module.exports = {
+  extends: [
+    // allow all reactivity apis (`ref`, `computed`, `watch`, etc.)
+    'vue-global-api-main/eslint-config/reactivity',
+    // allow register all lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, etc.)
+    'vue-global-api-main/eslint-config/lifecycle',
+    // allow register component apis (`inject`, `provide`, `h`, etc.)
+    'vue-global-api-main/eslint-config/component',
+    // allow singular api
+    'vue-global-api-main/eslint-config/defineProps',
+  ]
+};
+```
+
 ## License
 
 MIT License © 2021 [Anthony Fu](https://github.com/antfu)

--- a/README.md
+++ b/README.md
@@ -91,31 +91,32 @@ In [the latest `<script setup>`](https://github.com/vuejs/rfcs/pull/227), compil
 
 ## ESLint
 
-If you use ESLint it'll complain about you using undefined variables. This package provides a ESLint config you can extend from that will fix those issues.
+If you use ESLint it'll complain about you using undefined variables. This package provides the ESLint config presets to solve it.
 
-Just extend the config in your `.eslintrc.js`:
+Extend in your ESLint config:
 
 ```javascript
+// .eslintrc.js
 module.exports = {
   extends: [
-    'vue-global-api-main/eslint-config'
+    'vue-global-api/eslint-config'
   ]
 };
 ```
 
-This provides the same collections and single API options to allow you to have more fine-grain control.
+It also provides the same collections and single API options for fine-grain control.
 
 ```javascript
+// .eslintrc.js
 module.exports = {
   extends: [
-    // allow all reactivity apis (`ref`, `computed`, `watch`, etc.)
-    'vue-global-api-main/eslint-config/reactivity',
-    // allow register all lifecycle hooks (`onMounted`, `onUpdated`, `onUnmounted`, etc.)
-    'vue-global-api-main/eslint-config/lifecycle',
-    // allow register component apis (`inject`, `provide`, `h`, etc.)
-    'vue-global-api-main/eslint-config/component',
-    // allow singular api
-    'vue-global-api-main/eslint-config/defineProps',
+    // collections
+    'vue-global-api/eslint-config/reactivity',
+    'vue-global-api/eslint-config/lifecycle',
+    'vue-global-api/eslint-config/component',
+    // single apis
+    'vue-global-api/eslint-config/ref',
+    'vue-global-api/eslint-config/toRef',
   ]
 };
 ```

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "esno scripts/generate.ts",
     "prepublishOnly": "npm run build",
-    "clean": "rimraf *.cjs *.d.ts *.mjs",
+    "clean": "rimraf *.cjs *.d.ts *.mjs eslint-config",
     "release": "npx bumpp --commit --tag --push && npm publish"
   },
   "exports": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "release": "npx bumpp --commit --tag --push && npm publish"
   },
   "exports": {
+    "./eslint-config": "./eslint-config/index.js",
+    "./eslint-config/*": "./eslint-config/*",
     "./onActivated": {
       "import": "./onActivated.mjs",
       "require": "./onActivated.cjs"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "files": [
     "*.cjs",
     "*.mjs",
-    "*.d.ts"
+    "*.d.ts",
+    "eslint-config"
   ],
   "scripts": {
     "build": "esno scripts/generate.ts",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -58,7 +58,7 @@ const collections = {
   reactivity,
 }
 
-fs.ensureDir("./eslint-config/")
+fs.ensureDir('./eslint-config/')
 
 const eslintConfigIndex: {extends: string[]; globals: Record<string, 'readonly'>} = {
   extends: [],
@@ -70,13 +70,16 @@ const eslintConfigIndex: {extends: string[]; globals: Record<string, 'readonly'>
   },
 }
 const packageJSON = fs.readJSONSync('package.json')
-packageJSON.exports = {}
+packageJSON.exports = {
+  './eslint-config': './eslint-config/index.js',
+  './eslint-config/*': './eslint-config/*',
+}
 
 for (const api of apis) {
   fs.writeFile(`${api}.mjs`, `import { ${api} } from 'vue-demi'\nglobalThis.${api} = ${api}\n`, 'utf-8')
   fs.writeFile(`${api}.cjs`, `const { ${api} } = require('vue-demi')\nglobalThis.${api} = ${api}\n`, 'utf-8')
   fs.writeFile(`${api}.d.ts`, `import { ${api} as _${api} } from 'vue-demi'\ndeclare global {\n  const ${api}: typeof _${api}\n}\n`, 'utf-8')
-  fs.writeFile(`./eslint-config/${api}.js`, `module.exports = ${JSON.stringify({ globals: { api: 'readonly' } }, undefined, 2)}`, 'utf-8')
+  fs.writeFile(`./eslint-config/${api}.js`, `module.exports = {\n  globals: {\n    ${api}: 'readonly'\n  }\n}`, 'utf-8')
   packageJSON.exports[`./${api}`] = {
     import: `./${api}.mjs`,
     require: `./${api}.cjs`,
@@ -97,7 +100,7 @@ ${collection.map(api => `  const ${api}: typeof _${api}`).join('\n')}
   if (name === 'index') { entry = '.' }
   else {
     eslintConfigIndex.extends.push(`./${name}.js`)
-    fs.writeFile(`./eslint-config/${name}.js`, `module.exports = ${JSON.stringify({ globals: Object.fromEntries(collection.map(api => [api, 'readonly'])) }, undefined, 2)}`, 'utf-8')
+    fs.writeFile(`./eslint-config/${name}.js`, `module.exports = {\n  globals: {\n${collection.map(api => `    ${api}: 'readonly'`).join(',\n')}\n  }\n}`, 'utf-8')
   }
 
   packageJSON.exports[entry] = {


### PR DESCRIPTION
Allows 

`extends: ["vue-global-api-main/eslint-config"]` to put all the APIs in global scope.

And same as all the other collection or single api imports: `extends: ["vue-global-api-main/eslint-config/lifecycle"]` or `extends: ["vue-global-api-main/eslint-config/isRef"]`

